### PR TITLE
Add syrupy to test requirements

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -2,3 +2,4 @@ homecom_alt
 pytest
 pytest-cov
 pytest-homeassistant-custom-component
+syrupy


### PR DESCRIPTION
## Summary
- add `syrupy` to `requirements.test.txt` for snapshot tests

## Testing
- `pytest -q` *(fails: No module named 'syrupy')*

------
https://chatgpt.com/codex/tasks/task_e_68544a93887083229592ef98a82c4738