### PR TITLE
Fix service naming typo

### DIFF
--- a/custom_components/bosch_homecom/__init__.py
+++ b/custom_components/bosch_homecom/__init__.py
@@ -118,7 +118,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_setup(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Add custom action."""
 
-    async def set_dhw_tempreture_service(call: ServiceCall) -> None:
+    async def set_dhw_temperature_service(call: ServiceCall) -> None:
         """Service to change temperature."""
         for entity in call.data["entity_id"]:
             device_id = entity.split("_")[2]
@@ -143,7 +143,7 @@ async def async_setup(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Register our service with Home Assistant.
     hass.services.async_register(
-        DOMAIN, "set_dhw_tempreture", set_dhw_tempreture_service
+        DOMAIN, "set_dhw_temperature", set_dhw_temperature_service
     )
 
     async def set_dhw_extrahot_water_service(call: ServiceCall) -> None:

--- a/custom_components/bosch_homecom/services.yaml
+++ b/custom_components/bosch_homecom/services.yaml
@@ -1,4 +1,4 @@
-set_dhw_tempreture:
+set_dhw_temperature:
   name: Set DHW Temperature
   description: Set the temperature of dhw for a specific level
   target:
@@ -7,7 +7,7 @@ set_dhw_tempreture:
   fields:
     level:
       name: level
-      description: The tempreture level to set temperature for
+      description: The temperature level to set temperature for
       required: true
       default: "eco"
       example: "high"
@@ -19,7 +19,7 @@ set_dhw_tempreture:
             - "low"
     temperature:
       name: temperature
-      description: The tempreture to set to level of dhw circuit
+      description: The temperature to set to level of dhw circuit
       required: true
       example: 44.0
       selector:


### PR DESCRIPTION
## Summary
- fix typo in DHW temperature service name
- update service YAML

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'syrupy')*

------
https://chatgpt.com/codex/tasks/task_e_68544c24573c8322a08a0684e4367ad2