### PR TITLE
Fix typos in translations and code

### DIFF
--- a/custom_components/bosch_homecom/__init__.py
+++ b/custom_components/bosch_homecom/__init__.py
@@ -92,7 +92,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     device_registry = dr.async_get(hass)
 
-    # Create a new Device for each coorodinator to represent each module
+    # Create a new Device for each coordinator to represent each module
     for c in coordinators:
         device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,

--- a/custom_components/bosch_homecom/sensor.py
+++ b/custom_components/bosch_homecom/sensor.py
@@ -310,8 +310,8 @@ class BoschComSensorHc(BoschComSensorBase):
                     "heatCoolMode": heatCoolMode_value,
                 }
         return {
-            "currentSuWiMode": "unknonw",
-            "heatCoolMode": "unknonw",
+            "currentSuWiMode": "unknown",
+            "heatCoolMode": "unknown",
         }
 
 

--- a/custom_components/bosch_homecom/strings.json
+++ b/custom_components/bosch_homecom/strings.json
@@ -28,7 +28,7 @@
         "error": {
             "no_devices_found": "No devices found",
             "cannot_connect": "Cannot connect",
-            "unknown": "Unkown error"
+            "unknown": "Unknown error"
         },
         "abort": {
             "already_configured": "Already configured",

--- a/custom_components/bosch_homecom/translations/en.json
+++ b/custom_components/bosch_homecom/translations/en.json
@@ -28,7 +28,7 @@
         "error": {
             "no_devices_found": "No devices found",
             "cannot_connect": "Cannot connect",
-            "unknown": "Unkown error"
+            "unknown": "Unknown error"
         },
         "abort": {
             "already_configured": "Already configured",


### PR DESCRIPTION
## Summary
- fix Unknown string in translations
- correct fallback in sensors
- fix coordinator comment spelling

## Testing
- `pytest -q` *(fails: No module named 'syrupy')*

------
https://chatgpt.com/codex/tasks/task_e_68544d5f3e3c8322bb57321df23847fb