### PR TITLE
Add k30 model and update device registration

### DIFF
--- a/custom_components/bosch_homecom/__init__.py
+++ b/custom_components/bosch_homecom/__init__.py
@@ -99,7 +99,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             identifiers={(DOMAIN, c.device["deviceId"])},
             name=c.device["deviceId"],
             manufacturer="Bosch",
-            model=MODEL[c.device["deviceType"]],
+            model=MODEL.get(c.device["deviceType"], "Unknown"),
             sw_version=c.data.firmware,
         )
 

--- a/custom_components/bosch_homecom/const.py
+++ b/custom_components/bosch_homecom/const.py
@@ -12,6 +12,7 @@ MANUFACTURER: Final = "Bosch"
 MODEL = {
     "rac": "Residential Air Conditioning",
     "k40": "Bosch boiler",
+    "k30": "Bosch boiler k30",
 }
 
 ATTR_NOTIFICATIONS = "notifications"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -4,7 +4,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from custom_components.bosch_homecom.coordinator import BoschComModuleCoordinatorRac
 from custom_components.bosch_homecom.const import DOMAIN, MANUFACTURER, DEFAULT_UPDATE_INTERVAL
-from homecom_alt import ApiError, InvalidSensorDataError, AuthFailedError, BHCDevice
+from homecom_alt import ApiError, InvalidSensorDataError, AuthFailedError, BHCDeviceRac
 from tenacity import RetryError
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
@@ -52,7 +52,7 @@ def test_init_coordinator(hass, bhc, device, firmware):
 async def test_async_update_data_success(hass, bhc, device, firmware):
     """Test successful data update."""
     coordinator = BoschComModuleCoordinatorRac(hass, bhc, device, firmware)
-    bhc.async_update = AsyncMock(return_value=BHCDevice(
+    bhc.async_update = AsyncMock(return_value=BHCDeviceRac(
         device=device,
         firmware=firmware,
         notifications=[],

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,12 +1,17 @@
 """Test component setup."""
 import pathlib
-from custom_components.bosch_homecom.const import DOMAIN, MANUFACTURER, MODEL
+from custom_components.bosch_homecom.const import (
+    DOMAIN,
+    MANUFACTURER,
+    MODEL,
+    CONF_DEVICES,
+)
 from unittest.mock import Mock, AsyncMock, patch
 from homeassistant.helpers import device_registry as dr
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homecom_alt import BHCDevice
+from homecom_alt import BHCDeviceRac, BHCDeviceK40
 from homeassistant.setup import async_setup_component
 from collections.abc import Awaitable, Callable
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -26,12 +31,20 @@ def entry():
         domain=DOMAIN,
         title="test",
         unique_id="test",
-        data={CONF_USERNAME: "test-user", CONF_PASSWORD: "test-pass"},
+        data={
+            CONF_USERNAME: "test-user",
+            CONF_PASSWORD: "test-pass",
+            CONF_DEVICES: {},
+        },
     )
 
-@pytest.fixture()  
-def devices():  
+@pytest.fixture()
+def devices():
     return [{"deviceId":"123","deviceType":"rac"}]
+
+@pytest.fixture()
+def devices_k30():
+    return [{"deviceId":"123","deviceType":"k30"}]
 
 @pytest.fixture()
 def sensor_data():
@@ -45,18 +58,23 @@ def sensor_data():
 @pytest.mark.asyncio
 async def test_entry_setup_unload(hass, entry, devices, sensor_data):
     """Test config entry setup and unload."""
+    entry.data[CONF_DEVICES][
+        f"{devices[0]['deviceId']}_{devices[0]['deviceType']}"
+    ] = True
     entry.add_to_hass(hass)
 
     mock_api = AsyncMock()
-    mock_api.async_get_devices.return_value = AsyncMock(return_value=devices)()
+    mock_api.async_get_devices.return_value = AsyncMock(
+        return_value=AsyncMock(return_value=devices)
+    )()
     mock_api.async_get_firmware.return_value = {"value": "1.0.0"}
-    mock_api.async_update.return_value = BHCDevice(
-            device=devices[0]["deviceId"],
-            firmware=sensor_data["firmwares"],
-            notifications=sensor_data["notifications"],
-            stardard_functions=sensor_data["stardard_functions"],
-            advanced_functions=sensor_data["advanced_functions"],
-            switch_programs=sensor_data["switch_programs"],
+    mock_api.async_update.return_value = BHCDeviceRac(
+        device=devices[0]["deviceId"],
+        firmware=sensor_data["firmwares"],
+        notifications=sensor_data["notifications"],
+        stardard_functions=sensor_data["stardard_functions"],
+        advanced_functions=sensor_data["advanced_functions"],
+        switch_programs=sensor_data["switch_programs"],
         )
 
     with patch(
@@ -82,6 +100,64 @@ async def test_entry_setup_unload(hass, entry, devices, sensor_data):
     assert dev_entry.manufacturer == MANUFACTURER
     assert dev_entry.name == "Boschcom_rac_123"
     assert dev_entry.model == "Residential Air Conditioning"
+
+    with patch.object(
+        hass.config_entries, "async_forward_entry_unload", return_value=True
+    ) as unload:
+        assert await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+        assert unload.call_count == len(PLATFORMS)
+
+
+@pytest.mark.asyncio
+async def test_entry_setup_unload_k30(hass, entry, devices_k30, sensor_data):
+    """Test config entry setup for k30 device."""
+    entry.data[CONF_DEVICES][
+        f"{devices_k30[0]['deviceId']}_{devices_k30[0]['deviceType']}"
+    ] = True
+    entry.add_to_hass(hass)
+
+    mock_api = AsyncMock()
+    mock_api.async_get_devices.return_value = AsyncMock(
+        return_value=AsyncMock(return_value=devices_k30)
+    )()
+    mock_api.async_get_firmware.return_value = {"value": "1.0.0"}
+    mock_api.async_update.return_value = BHCDeviceK40(
+        device=devices_k30[0]["deviceId"],
+        firmware=sensor_data["firmwares"],
+        notifications=sensor_data["notifications"],
+        holiday_mode=None,
+        away_mode=None,
+        consumption=None,
+        power_limitation=None,
+        hs_pump_type=None,
+        dhw_circuits=[],
+        heating_circuits=[],
+    )
+
+    with patch(
+        "custom_components.bosch_homecom.config_flow.async_check_credentials",
+        return_value=None,
+    ), patch(
+        "custom_components.bosch_homecom.HomeComAlt.create",
+        return_value=mock_api,
+    ), patch.object(
+        hass.config_entries, "async_forward_entry_setup", return_value=True
+    ) as setup:
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    dev_reg = dr.async_get(hass)
+    dev_entries = dr.async_entries_for_config_entry(dev_reg, entry.entry_id)
+
+    assert dev_entries
+    dev_entry = dev_entries[0]
+    assert dev_entry.identifiers == {
+        (DOMAIN, devices_k30[0]["deviceId"])
+    }
+    assert dev_entry.manufacturer == MANUFACTURER
+    assert dev_entry.name == "Boschcom_k30_123"
+    assert dev_entry.model == "Bosch boiler k30"
 
     with patch.object(
         hass.config_entries, "async_forward_entry_unload", return_value=True


### PR DESCRIPTION
## Summary
- include new k30 model in constant mapping
- fall back to "Unknown" if device type missing during device registration
- support new k30 device in tests

## Testing
- `pytest -q` *(fails: cannot access local variable 'devices' and network errors)*

------
https://chatgpt.com/codex/tasks/task_e_685451ca31bc8322a2d4737541dad997